### PR TITLE
fix(db): column 수정 시 foreign key check 비활성화

### DIFF
--- a/backend/foodtruck/src/main/resources/db/migration/V1.5__drop_table_participation.sql
+++ b/backend/foodtruck/src/main/resources/db/migration/V1.5__drop_table_participation.sql
@@ -6,7 +6,7 @@ UPDATE truck t
 
 ALTER TABLE truck ADD FOREIGN KEY(event_id) REFERENCES event(event_id);
 
--- add truck_id to menu, order_info and drop participation_id
+-- add truck_id to menu, order_info
 ALTER TABLE menu ADD truck_id BIGINT(20);
 ALTER TABLE order_info ADD truck_id BIGINT(20);
 
@@ -16,8 +16,10 @@ UPDATE menu m
 UPDATE order_info o
     SET o.truck_id = (SELECT p.truck_id FROM participation p WHERE o.participation_id = p.participation_id);
 
+-- drop participation
+SET FOREIGN_KEY_CHECKS=0;
 ALTER TABLE menu DROP participation_id;
 ALTER TABLE order_info DROP participation_id;
+SET FOREIGN_KEY_CHECKS=1;
 
--- drop participation
 DROP TABLE participation;


### PR DESCRIPTION
### Motivation
<!--요구 사항 또는 작업 동기-->
flyway migration 실행 중 foreign key column 삭제에서 오류 발생

### Key Changes
<!--주요한 변화들-->
column 수정 전 foreign key check 비활성화

### Note
<!--참고 사항 및 추가로 작성하고 싶은 내용-->

<!--관련 이슈 있을 경우-->
<!--Close #{이슈번호}-->
