### PR TITLE
refactor(test): `DisplayName`을 nested class와 test method가 문장형으로 이어지도록 수정

### DIFF
--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/auth/AuthAcceptanceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/auth/AuthAcceptanceTest.java
@@ -1,4 +1,4 @@
-package com.connectruck.foodtruck.auth.controller;
+package com.connectruck.foodtruck.auth;
 
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.http.HttpStatus.OK;

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/auth/controller/AuthControllerTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/auth/controller/AuthControllerTest.java
@@ -22,7 +22,7 @@ public class AuthControllerTest extends ControllerTestBase {
 
         private static final String URI = BASE_URI + "/signin";
 
-        @DisplayName("아이디가 비어있을 경우 Bad Request를 응답한다.")
+        @DisplayName("할 때, 아이디가 비어있으면 Bad Request를 응답한다.")
         @ParameterizedTest
         @NullAndEmptySource
         void returnBadRequest_whenUsernameIsBlank(final String blank) throws Exception {
@@ -37,7 +37,7 @@ public class AuthControllerTest extends ControllerTestBase {
                     .andExpect(jsonPath("detail", stringContainsInOrder("필수", "아이디")));
         }
 
-        @DisplayName("비밀번호가 비어있을 경우 Bad Request를 응답한다.")
+        @DisplayName("할 때, 비밀번호가 비어있으면 Bad Request를 응답한다.")
         @ParameterizedTest
         @NullAndEmptySource
         void returnBadRequest_whenPasswordIsBlank(final String blank) throws Exception {

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/auth/controller/AuthenticationInterceptorTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/auth/controller/AuthenticationInterceptorTest.java
@@ -58,7 +58,7 @@ class AuthenticationInterceptorTest {
 
         private final String validToken = jwtTokenProvider.create("1", Role.OWNER.name());
 
-        @DisplayName("토큰이 유효하면 요청에 성공한다.")
+        @DisplayName("하여 토큰이 유효하면 요청을 처리한다.")
         @ParameterizedTest
         @ValueSource(strings = {URI_METHOD_ANNOTATED, URI_TYPE_ANNOTATED})
         void success(final String uri) throws Exception {
@@ -71,7 +71,7 @@ class AuthenticationInterceptorTest {
             resultActions.andExpect(status().isOk());
         }
 
-        @DisplayName("토큰이 없으면 요청에 실패한다.")
+        @DisplayName("할 때, 토큰이 없으면 예외가 발생한다.")
         @ParameterizedTest
         @ValueSource(strings = {URI_METHOD_ANNOTATED, URI_TYPE_ANNOTATED})
         void returnUnauthorized_withoutToken(final String uri) throws Exception {
@@ -86,7 +86,7 @@ class AuthenticationInterceptorTest {
                     .andExpect(jsonPath("detail").value("토큰이 존재하지 않습니다."));
         }
 
-        @DisplayName("토큰 형식이 잘못되었으면 요청에 실패한다.")
+        @DisplayName("할 때, 토큰 형식이 잘못되었으면 예외가 발생한다.")
         @ParameterizedTest
         @ValueSource(strings = {URI_METHOD_ANNOTATED, URI_TYPE_ANNOTATED})
         void returnUnauthorized_whenTokenIsNotBearer(final String uri) throws Exception {
@@ -102,7 +102,7 @@ class AuthenticationInterceptorTest {
                     .andExpect(jsonPath("detail").value("식별할 수 없는 형식의 토큰입니다."));
         }
 
-        @DisplayName("토큰이 유효하지 않으면 요청에 실패한다.")
+        @DisplayName("할 때, 토큰이 유효하지 않으면 예외가 발생한다.")
         @ParameterizedTest
         @ValueSource(strings = {URI_METHOD_ANNOTATED, URI_TYPE_ANNOTATED})
         void returnUnauthorized_whenTokenInvalid(final String uri) throws Exception {

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/auth/controller/AuthorizationInterceptorTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/auth/controller/AuthorizationInterceptorTest.java
@@ -64,7 +64,7 @@ class AuthorizationInterceptorTest {
 
         private final String validToken = jwtTokenProvider.create(Long.toString(ID), REQUIRED_ROLE.name());
 
-        @DisplayName("사장님 권한이 있으면 요청에 성공한다.")
+        @DisplayName("하여 권한이 있으면 요청을 처리한다.")
         @Test
         void success() throws Exception {
             // given
@@ -79,7 +79,7 @@ class AuthorizationInterceptorTest {
             resultActions.andExpect(status().isOk());
         }
 
-        @DisplayName("토큰이 유효하지 않으면 요청에 실패한다.")
+        @DisplayName("할 때, 토큰이 유효하지 않으면 예외가 발생한다.")
         @ParameterizedTest
         @ValueSource(strings = {URI_METHOD_ANNOTATED, URI_TYPE_ANNOTATED})
         void returnUnauthorized_whenTokenInvalid(final String uri) throws Exception {
@@ -95,7 +95,7 @@ class AuthorizationInterceptorTest {
                     .andExpect(jsonPath("detail").value("유효하지 않은 토큰입니다."));
         }
 
-        @DisplayName("사장님 권한이 없으면 요청에 실패한다.")
+        @DisplayName("할 때, 사장님 권한이 없으면 예외가 발생한다.")
         @ParameterizedTest
         @ValueSource(strings = {URI_METHOD_ANNOTATED, URI_TYPE_ANNOTATED})
         void returnForbidden_whenNotOwnerToken(final String uri) throws Exception {
@@ -111,7 +111,7 @@ class AuthorizationInterceptorTest {
             resultActions.andExpect(status().isForbidden());
         }
 
-        @DisplayName("토큰에만 사장님 권한이 있으면 요청에 실패한다.")
+        @DisplayName("할 때, 토큰에만 사장님 권한이 있으면 예외가 발생한다.")
         @ParameterizedTest
         @ValueSource(strings = {URI_METHOD_ANNOTATED, URI_TYPE_ANNOTATED})
         void returnForbidden_whenNotOwnerAccount(final String uri) throws Exception {

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/auth/service/AuthServiceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/auth/service/AuthServiceTest.java
@@ -61,7 +61,7 @@ public class AuthServiceTest extends ServiceTestBase {
                     .isThrownBy(() -> authService.signIn(request));
         }
 
-        @DisplayName("할 떄, 비밀번호가 일치하지 않으면 예외가 발생한다.")
+        @DisplayName("할 때, 비밀번호가 일치하지 않으면 예외가 발생한다.")
         @Test
         void throwsException_whenWrongPassword() {
             // given

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/auth/service/AuthServiceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/auth/service/AuthServiceTest.java
@@ -31,7 +31,7 @@ public class AuthServiceTest extends ServiceTestBase {
         final String username = "test";
         final String password = "test1234!";
 
-        @DisplayName("로그인에 성공하면 access token을 발급한다.")
+        @DisplayName("한 뒤 access token을 발급받는다.")
         @Test
         void returnAccessToken() {
             // given
@@ -53,7 +53,7 @@ public class AuthServiceTest extends ServiceTestBase {
             );
         }
 
-        @DisplayName("아이디가 잘못되었을 경우 예외가 발생한다.")
+        @DisplayName("할 때, 잘못된 아이디면 예외가 발생한다.")
         @Test
         void throwsException_whenWrongUsername() {
             final SignInRequest request = new SignInRequest("test", "test1234!");
@@ -61,7 +61,7 @@ public class AuthServiceTest extends ServiceTestBase {
                     .isThrownBy(() -> authService.signIn(request));
         }
 
-        @DisplayName("비밀번호가 일치하지 않을 경우 예외가 발생한다.")
+        @DisplayName("할 떄, 비밀번호가 일치하지 않으면 예외가 발생한다.")
         @Test
         void throwsException_whenWrongPassword() {
             // given

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/common/validation/ValidatorTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/common/validation/ValidatorTest.java
@@ -16,7 +16,7 @@ class ValidatorTest {
     @Nested
     class validatePhone {
 
-        @DisplayName("형식에 맞을 경우 예외가 발생하지 않는다.")
+        @DisplayName("하여 형식에 맞으면 성공한다.")
         @ParameterizedTest
         @ValueSource(strings = {"01000000000", "01112341234", "0161231234", "01912341234"})
         void success(final String validPhone) {
@@ -24,7 +24,7 @@ class ValidatorTest {
                     .isThrownBy(() -> Validator.validatePhone(validPhone));
         }
 
-        @DisplayName("형식이 잘못되었을 경우 예외가 발생한다.")
+        @DisplayName("할 때, 형식이 잘못되었으면 예외가 발생한다.")
         @ParameterizedTest
         @ValueSource(strings = {"11012341234", "01212341234", "010121234", "010a1231234", "010-1234-1234"})
         void throwsException_whenPhoneInvalid(final String invalidPhone) {

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/event/EventAcceptanceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/event/EventAcceptanceTest.java
@@ -15,15 +15,15 @@ public class EventAcceptanceTest extends AcceptanceTestBase {
 
     private static final String BASE_URI = "/api/events";
 
-    @DisplayName("행사 정보 조회")
+    @DisplayName("id로 행사 정보 조회")
     @Nested
     class findOneEvent {
 
         private static final String URI_FORMAT = BASE_URI + "/%d";
 
-        @DisplayName("특정 행사의 정보를 id로 조회한다.")
+        @DisplayName("할 수 있다.")
         @Test
-        void byId() {
+        void success() {
             // given
             final Event expected = dataSetup.saveEvent(밤도깨비_야시장.create());
 

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/event/EventAcceptanceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/event/EventAcceptanceTest.java
@@ -1,4 +1,4 @@
-package com.connectruck.foodtruck.event.controller;
+package com.connectruck.foodtruck.event;
 
 import static com.connectruck.foodtruck.common.fixture.data.EventFixture.밤도깨비_야시장;
 import static org.hamcrest.Matchers.equalTo;

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/event/service/EventServiceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/event/service/EventServiceTest.java
@@ -19,11 +19,11 @@ class EventServiceTest extends ServiceTestBase {
     @Autowired
     private EventService eventService;
 
-    @DisplayName("행사 정보 조회")
+    @DisplayName("id로 행사 정보 단건 조회")
     @Nested
     class findById {
 
-        @DisplayName("특정 행사의 정보를 id로 조회한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -39,7 +39,7 @@ class EventServiceTest extends ServiceTestBase {
             );
         }
 
-        @DisplayName("해당하는 행사가 존재하지 않으면 예외가 발생한다.")
+        @DisplayName("할 떄, 해당하는 행사가 없으면 예외가 발생한다.")
         @Test
         void throwsException_whenEventNotFound() {
             // given

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/event/service/EventServiceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/event/service/EventServiceTest.java
@@ -39,7 +39,7 @@ class EventServiceTest extends ServiceTestBase {
             );
         }
 
-        @DisplayName("할 떄, 해당하는 행사가 없으면 예외가 발생한다.")
+        @DisplayName("할 때, 해당하는 행사가 없으면 예외가 발생한다.")
         @Test
         void throwsException_whenEventNotFound() {
             // given

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/menu/MenuAcceptanceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/menu/MenuAcceptanceTest.java
@@ -11,35 +11,29 @@ import com.connectruck.foodtruck.menu.domain.Menu;
 import com.connectruck.foodtruck.truck.domain.Truck;
 import io.restassured.response.ValidatableResponse;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class MenuAcceptanceTest extends AcceptanceTestBase {
 
     private static final String BASE_URI_FORMAT = "/api/trucks/%d/menus";
 
-    @DisplayName("푸드트럭 메뉴 목록 조회")
-    @Nested
-    class findMenusOfTruck {
+    @DisplayName("푸드트럭 id로 메뉴 목록을 조회한다.")
+    @Test
+    void findMenusOfTruck() {
+        // given
+        final Event event = 밤도깨비_야시장.create();
+        dataSetup.saveEvent(event);
 
-        @DisplayName("푸드트럭의 id로 메뉴 목록을 조회한다.")
-        @Test
-        void byTruckId() {
-            // given
-            final Event event = 밤도깨비_야시장.create();
-            dataSetup.saveEvent(event);
+        final Truck savedTruck = dataSetup.saveTruck(event);
+        final Menu expected = dataSetup.saveMenu(savedTruck);
 
-            final Truck savedTruck = dataSetup.saveTruck(event);
-            final Menu expected = dataSetup.saveMenu(savedTruck);
+        // when
+        final ValidatableResponse response = get(String.format(BASE_URI_FORMAT, savedTruck.getId()));
 
-            // when
-            final ValidatableResponse response = get(String.format(BASE_URI_FORMAT, savedTruck.getId()));
-
-            // then
-            response.statusCode(OK.value())
-                    .body("menus", hasSize(1))
-                    .body("menus.id", contains(expected.getId().intValue()))
-                    .body("menus.name", contains(expected.getName()));
-        }
+        // then
+        response.statusCode(OK.value())
+                .body("menus", hasSize(1))
+                .body("menus.id", contains(expected.getId().intValue()))
+                .body("menus.name", contains(expected.getName()));
     }
 }

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/menu/MenuAcceptanceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/menu/MenuAcceptanceTest.java
@@ -1,4 +1,4 @@
-package com.connectruck.foodtruck.menu.controller;
+package com.connectruck.foodtruck.menu;
 
 import static com.connectruck.foodtruck.common.fixture.data.EventFixture.밤도깨비_야시장;
 import static org.hamcrest.Matchers.contains;

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/menu/OwnerMenuAcceptanceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/menu/OwnerMenuAcceptanceTest.java
@@ -1,4 +1,4 @@
-package com.connectruck.foodtruck.menu.controller;
+package com.connectruck.foodtruck.menu;
 
 import static com.connectruck.foodtruck.common.fixture.data.EventFixture.밤도깨비_야시장;
 import static org.hamcrest.Matchers.contains;

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/menu/service/MenuServiceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/menu/service/MenuServiceTest.java
@@ -103,7 +103,7 @@ class MenuServiceTest extends ServiceTestBase {
                     .isThrownBy(() -> menuService.updateDescription(request, savedMenu.getId(), owner.getId()));
         }
 
-        @DisplayName("할 떄, 존재하지 않는 메뉴면 예외가 발생한다.")
+        @DisplayName("할 때, 존재하지 않는 메뉴면 예외가 발생한다.")
         @Test
         void throwException_ifMenuNotFound() {
             // given
@@ -116,7 +116,7 @@ class MenuServiceTest extends ServiceTestBase {
                     .withMessageContainingAll("메뉴", "존재하지 않습니다.");
         }
 
-        @DisplayName("할 떄, 소유한 푸드트럭이 없으면 예외가 발생한다.")
+        @DisplayName("할 때, 소유한 푸드트럭이 없으면 예외가 발생한다.")
         @Test
         void throwsException_whenNoOwningTruck() {
             // given

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/menu/service/MenuServiceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/menu/service/MenuServiceTest.java
@@ -37,11 +37,11 @@ class MenuServiceTest extends ServiceTestBase {
         savedTruck = dataSetup.saveTruck(savedEvent, owner.getId());
     }
 
-    @DisplayName("푸드트럭 메뉴 목록 조회")
+    @DisplayName("푸드트럭 id로 메뉴 목록 조회")
     @Nested
     class findByTruckId {
 
-        @DisplayName("푸드트럭의 id로 메뉴 목록을 조회한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -56,11 +56,11 @@ class MenuServiceTest extends ServiceTestBase {
         }
     }
 
-    @DisplayName("사장님 소유 푸드트럭 메뉴 목록 조회")
+    @DisplayName("사장님 id로 소유 푸드트럭 메뉴 목록 조회")
     @Nested
     class findByOwnerId {
 
-        @DisplayName("사장님 id로 소유한 푸드트럭의 메뉴 목록을 조회한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -74,7 +74,7 @@ class MenuServiceTest extends ServiceTestBase {
             assertThat(response.menus()).hasSize(2);
         }
 
-        @DisplayName("소유한 푸드트럭이 없으면 예외가 발생한다.")
+        @DisplayName("할 때, 소유한 푸드트럭이 없으면 예외가 발생한다.")
         @Test
         void throwsException_whenNoOwningTruck() {
             // given
@@ -91,7 +91,7 @@ class MenuServiceTest extends ServiceTestBase {
     @Nested
     class updateDetail {
 
-        @DisplayName("소유한 푸드트럭 메뉴의 설명을 수정한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -103,7 +103,7 @@ class MenuServiceTest extends ServiceTestBase {
                     .isThrownBy(() -> menuService.updateDescription(request, savedMenu.getId(), owner.getId()));
         }
 
-        @DisplayName("해당하는 메뉴가 없으면 예외가 발생한다.")
+        @DisplayName("할 떄, 존재하지 않는 메뉴면 예외가 발생한다.")
         @Test
         void throwException_ifMenuNotFound() {
             // given
@@ -116,7 +116,7 @@ class MenuServiceTest extends ServiceTestBase {
                     .withMessageContainingAll("메뉴", "존재하지 않습니다.");
         }
 
-        @DisplayName("소유한 푸드트럭이 없으면 예외가 발생한다.")
+        @DisplayName("할 떄, 소유한 푸드트럭이 없으면 예외가 발생한다.")
         @Test
         void throwsException_whenNoOwningTruck() {
             // given
@@ -132,7 +132,7 @@ class MenuServiceTest extends ServiceTestBase {
                     .withMessageContainingAll("소유한 푸드트럭", "존재하지 않습니다.");
         }
 
-        @DisplayName("소유한 푸드트럭의 메뉴가 아니면 예외가 발생한다.")
+        @DisplayName("할 때, 소유한 푸드트럭의 메뉴가 아니면 예외가 발생한다.")
         @Test
         void throwsException_whenNotOwnerOfMenu() {
             // given
@@ -151,7 +151,7 @@ class MenuServiceTest extends ServiceTestBase {
     @Nested
     class updateSoldOut {
 
-        @DisplayName("소유한 푸드트럭 메뉴의 품절 상태를 수정한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -163,7 +163,7 @@ class MenuServiceTest extends ServiceTestBase {
                     .isThrownBy(() -> menuService.updateSoldOut(request, savedMenu.getId(), owner.getId()));
         }
 
-        @DisplayName("해당하는 메뉴가 없으면 예외가 발생한다.")
+        @DisplayName("할 때, 존재하지 않는 메뉴면 예외가 발생한다.")
         @Test
         void throwException_ifMenuNotFound() {
             // given
@@ -176,7 +176,7 @@ class MenuServiceTest extends ServiceTestBase {
                     .withMessageContainingAll("메뉴", "존재하지 않습니다.");
         }
 
-        @DisplayName("소유한 푸드트럭이 없으면 예외가 발생한다.")
+        @DisplayName("할 때, 소유한 푸드트럭이 없으면 예외가 발생한다.")
         @Test
         void throwsException_whenNoOwningTruck() {
             // given
@@ -192,7 +192,7 @@ class MenuServiceTest extends ServiceTestBase {
                     .withMessageContainingAll("소유한 푸드트럭", "존재하지 않습니다.");
         }
 
-        @DisplayName("소유한 푸드트럭의 메뉴가 아니면 예외가 발생한다.")
+        @DisplayName("할 때, 소유한 푸드트럭의 메뉴가 아니면 예외가 발생한다.")
         @Test
         void throwsException_whenNotOwnerOfMenu() {
             // given

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/notification/NotificationAcceptanceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/notification/NotificationAcceptanceTest.java
@@ -1,4 +1,4 @@
-package com.connectruck.foodtruck.notification.controller;
+package com.connectruck.foodtruck.notification;
 
 import static com.connectruck.foodtruck.common.fixture.data.EventFixture.밤도깨비_야시장;
 import static org.springframework.http.HttpStatus.NO_CONTENT;

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/notification/service/PushNotificationServiceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/notification/service/PushNotificationServiceTest.java
@@ -44,7 +44,7 @@ class PushNotificationServiceTest extends ServiceTestBase {
     @Nested
     class subscribeOrders {
 
-        @DisplayName("소유한 푸드트럭의 주문 알림을 구독한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -58,7 +58,7 @@ class PushNotificationServiceTest extends ServiceTestBase {
                     .isThrownBy(() -> pushNotificationService.subscribeOrders(request, owner.getId()));
         }
 
-        @DisplayName("소유 푸드트럭에 대해 이미 구독된 기기이면 새 구독 정보를 생성하지 않는다.")
+        @DisplayName("할 때, 이미 구독된 기기이면 새 구독 정보를 생성하지 않는다.")
         @Test
         void success_whenAlreadySubscribed() {
             // given
@@ -74,7 +74,7 @@ class PushNotificationServiceTest extends ServiceTestBase {
                     .isThrownBy(() -> pushNotificationService.subscribeOrders(request, owner.getId()));
         }
 
-        @DisplayName("소유한 푸드트럭이 없으면 예외가 발생한다.")
+        @DisplayName("할 때, 소유한 푸드트럭이 없으면 예외가 발생한다.")
         @Test
         void throwsException_whenNoOwningTruck() {
             // given
@@ -104,12 +104,12 @@ class PushNotificationServiceTest extends ServiceTestBase {
                 .isThrownBy(() -> pushNotificationService.unsubscribeOrders(request, owner.getId()));
     }
 
-    @DisplayName("사장님 주문 알림 발송")
+    @DisplayName("해당 푸드트럭 구독 기기에 주문 알림 발송")
     @Nested
     class notifyOrderToOwner {
 
         @Test
-        @DisplayName("해당 푸드트럭의 주문 알림 구독자에게 알림을 발송한다.")
+        @DisplayName("할 수 있다.")
         void success() {
             // given
             // 구독 정보 저장
@@ -135,7 +135,7 @@ class PushNotificationServiceTest extends ServiceTestBase {
         }
 
         @Test
-        @DisplayName("발송에 실패한 토큰이 있을 경우 해당 구독 정보를 삭제한다.")
+        @DisplayName("할 때, 발송에 실패한 토큰이 있을 경우 해당 구독 정보를 삭제한다.")
         void deleteSubscription_whenTokenFailed() {
             // given
             // 구독 정보 저장

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/order/OrderAcceptanceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/order/OrderAcceptanceTest.java
@@ -1,4 +1,4 @@
-package com.connectruck.foodtruck.order.controller;
+package com.connectruck.foodtruck.order;
 
 import static com.connectruck.foodtruck.common.fixture.data.EventFixture.밤도깨비_야시장;
 import static org.hamcrest.Matchers.contains;

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/order/OwnerOrderAcceptanceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/order/OwnerOrderAcceptanceTest.java
@@ -1,4 +1,4 @@
-package com.connectruck.foodtruck.order.controller;
+package com.connectruck.foodtruck.order;
 
 import static com.connectruck.foodtruck.common.fixture.data.EventFixture.밤도깨비_야시장;
 import static org.hamcrest.Matchers.contains;

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/order/OwnerOrderAcceptanceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/order/OwnerOrderAcceptanceTest.java
@@ -44,13 +44,13 @@ public class OwnerOrderAcceptanceTest extends AcceptanceTestBase {
         savedMenu = dataSetup.saveMenu(owningTruck);
     }
 
-    @DisplayName("소유 푸드트럭의 상태별 주문 목록 조회")
+    @DisplayName("소유 푸드트럭의 상태별 주문 목록 페이지 조회")
     @Nested
     class findMyOrders {
 
         private static final String URI = BASE_URI + "/my";
 
-        @DisplayName("모든 주문을 최신순으로 정렬하여 특정 페이지를 조회한다.")
+        @DisplayName("할 때 상태를 지정하지 않으면 모든 주문을 최신순으로 정렬하여 조회한다.")
         @Test
         void all_perPage() {
             // given
@@ -73,7 +73,7 @@ public class OwnerOrderAcceptanceTest extends AcceptanceTestBase {
                     .body("orders.id", contains(expected.getId().intValue()));
         }
 
-        @DisplayName("특정 상태의 주문을 조회한다.")
+        @DisplayName("할 때 상태를 지정하면 해당 상태의 주문을 최신순으로 정렬하여 조회한다.")
         @Test
         void byStatus_perPage() {
             // given
@@ -99,7 +99,7 @@ public class OwnerOrderAcceptanceTest extends AcceptanceTestBase {
                     .body("orders.status", contains("접수 대기"));
         }
 
-        @DisplayName("페이지와 사이즈를 지정하지 않으면 첫 20개를 조회한다.")
+        @DisplayName("할 떄 페이지와 사이즈를 지정하지 않으면 첫 20개를 조회한다.")
         @Test
         void findFirst20_withNoPageAndSize() {
             // given & when

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/order/OwnerOrderAcceptanceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/order/OwnerOrderAcceptanceTest.java
@@ -50,7 +50,7 @@ public class OwnerOrderAcceptanceTest extends AcceptanceTestBase {
 
         private static final String URI = BASE_URI + "/my";
 
-        @DisplayName("할 때 상태를 지정하지 않으면 모든 주문을 최신순으로 정렬하여 조회한다.")
+        @DisplayName("할 때, 상태를 지정하지 않으면 모든 주문을 최신순으로 정렬하여 조회한다.")
         @Test
         void all_perPage() {
             // given
@@ -73,7 +73,7 @@ public class OwnerOrderAcceptanceTest extends AcceptanceTestBase {
                     .body("orders.id", contains(expected.getId().intValue()));
         }
 
-        @DisplayName("할 때 상태를 지정하면 해당 상태의 주문을 최신순으로 정렬하여 조회한다.")
+        @DisplayName("할 때, 상태를 지정하면 해당 상태의 주문을 최신순으로 정렬하여 조회한다.")
         @Test
         void byStatus_perPage() {
             // given
@@ -99,7 +99,7 @@ public class OwnerOrderAcceptanceTest extends AcceptanceTestBase {
                     .body("orders.status", contains("접수 대기"));
         }
 
-        @DisplayName("할 떄 페이지와 사이즈를 지정하지 않으면 첫 20개를 조회한다.")
+        @DisplayName("할 때, 페이지와 사이즈를 지정하지 않으면 첫 20개를 조회한다.")
         @Test
         void findFirst20_withNoPageAndSize() {
             // given & when

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/order/controller/OrderControllerTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/order/controller/OrderControllerTest.java
@@ -28,7 +28,7 @@ class OrderControllerTest extends ControllerTestBase {
         private static final String PHONE = "01000000000";
         private static final List<OrderLineRequest> MENUS = List.of(new OrderLineRequest(1L, 2));
 
-        @DisplayName("푸드트럭 id가 없을 경우 Bad Request를 응답한다.")
+        @DisplayName("할 때, 푸드트럭 id가 없으면 Bad Request를 응답한다.")
         @Test
         void returnBadRequest_whenTruckIdIsNull() throws Exception {
             // given
@@ -44,7 +44,7 @@ class OrderControllerTest extends ControllerTestBase {
                     .andExpect(jsonPath("detail", stringContainsInOrder("필수", "푸드트럭 id")));
         }
 
-        @DisplayName("휴대폰 번호 형식이 잘못되었을 경우 Bad Request를 응답한다.")
+        @DisplayName("할 때, 휴대폰 번호 형식이 잘못되었으면 Bad Request를 응답한다.")
         @ParameterizedTest
         @ValueSource(strings = {"11012341234", "01212341234", "010121234", "010a1231234", "010-1234-1234"})
         void returnBadRequest_whenPhoneInvalid(final String invalidPhone) throws Exception {
@@ -61,7 +61,7 @@ class OrderControllerTest extends ControllerTestBase {
                     .andExpect(jsonPath("detail", stringContainsInOrder("형식", "휴대폰 번호")));
         }
 
-        @DisplayName("주문 메뉴 목록이 비어있을 경우 Bad Request를 응답한다.")
+        @DisplayName("할 때, 주문 메뉴 목록이 비어있으면 Bad Request를 응답한다.")
         @ParameterizedTest
         @NullAndEmptySource
         void returnBadRequest_whenMenuIsBlank(final List<OrderLineRequest> blankMenus) throws Exception {
@@ -78,7 +78,7 @@ class OrderControllerTest extends ControllerTestBase {
                     .andExpect(jsonPath("detail", stringContainsInOrder("필수", "주문 메뉴")));
         }
 
-        @DisplayName("주문 메뉴의 메뉴 id가 없을 경우 Bad Request를 응답한다.")
+        @DisplayName("할 때, 주문 메뉴의 메뉴 id가 없으면 Bad Request를 응답한다.")
         @Test
         void returnBadRequest_whenMenuIdIsNull() throws Exception {
             // given
@@ -94,7 +94,7 @@ class OrderControllerTest extends ControllerTestBase {
                     .andExpect(jsonPath("detail", stringContainsInOrder("필수", "메뉴 id")));
         }
 
-        @DisplayName("주문 메뉴의 수량이 0 이하일 경우 Bad Request를 응답한다.")
+        @DisplayName("할 때, 주문 메뉴의 수량이 0 이하면 Bad Request를 응답한다.")
         @ParameterizedTest
         @ValueSource(ints = {0, -1})
         void returnBadRequest_whenQuantityIsNotPositive(final int quantity) throws Exception {
@@ -116,7 +116,7 @@ class OrderControllerTest extends ControllerTestBase {
     @Nested
     class findByIdAndOrdererInfo {
 
-        @DisplayName("휴대폰 번호 형식이 잘못되었을 경우 Bad Request를 응답한다.")
+        @DisplayName("할 때, 휴대폰 번호 형식이 잘못되었으면 Bad Request를 응답한다.")
         @ParameterizedTest
         @ValueSource(strings = {"11012341234", "01212341234", "010121234", "010a1231234", "010-1234-1234"})
         void returnBadRequest_whenPhoneInvalid(final String invalidPhone) throws Exception {

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/order/domain/OrderInfoTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/order/domain/OrderInfoTest.java
@@ -36,7 +36,7 @@ class OrderInfoTest {
     @Nested
     class changeStatus {
 
-        @DisplayName("접수 대기 상태가 아닌 주문을 조리중 상태로 변경하면 예외가 발생한다.")
+        @DisplayName("할 때, 접수 대기 상태가 아닌 주문을 조리중 상태로 변경하면 예외가 발생한다.")
         @ParameterizedTest
         @ValueSource(strings = {"COOKING", "COOKED", "COMPLETE", "CANCELED"})
         void toCooking(final String unacceptableStatus) {
@@ -53,7 +53,7 @@ class OrderInfoTest {
                     .withMessageContaining("변경할 수 없습니다");
         }
 
-        @DisplayName("조리중 상태가 아닌 주문을 조리 완료 상태로 변경하면 예외가 발생한다.")
+        @DisplayName("할 때, 조리중 상태가 아닌 주문을 조리 완료 상태로 변경하면 예외가 발생한다.")
         @ParameterizedTest
         @ValueSource(strings = {"CREATED", "COOKED", "COMPLETE", "CANCELED"})
         void toCooked(final String notCookingStatus) {
@@ -70,7 +70,7 @@ class OrderInfoTest {
                     .withMessageContaining("변경할 수 없습니다");
         }
 
-        @DisplayName("조리 완료 상태가 아닌 주문을 픽업 완료 상태로 변경하면 예외가 발생한다.")
+        @DisplayName("할 때, 조리 완료 상태가 아닌 주문을 픽업 완료 상태로 변경하면 예외가 발생한다.")
         @ParameterizedTest
         @ValueSource(strings = {"CREATED", "COOKING", "COMPLETE", "CANCELED"})
         void toComplete(final String notCookedStatus) {
@@ -87,7 +87,7 @@ class OrderInfoTest {
                     .withMessageContaining("변경할 수 없습니다");
         }
 
-        @DisplayName("진행중이 아닌 주문을 취소 상태로 변경하면 예외가 발생한다.")
+        @DisplayName("할 때, 진행중이 아닌 주문을 취소 상태로 변경하면 예외가 발생한다.")
         @ParameterizedTest
         @ValueSource(strings = {"COMPLETE", "CANCELED"})
         void toCanceled(final String notInProgressStatus) {

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/order/service/OrderServiceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/order/service/OrderServiceTest.java
@@ -131,7 +131,7 @@ class OrderServiceTest extends ServiceTestBase {
                     .withMessageContaining("메뉴");
         }
 
-        @DisplayName("할 떄, 해당 푸드트럭의 메뉴가 아니면 예외가 발생한다.")
+        @DisplayName("할 때, 해당 푸드트럭의 메뉴가 아니면 예외가 발생한다.")
         @Test
         void throwsException_whenMenuOfOtherTruck() {
             // given
@@ -216,7 +216,7 @@ class OrderServiceTest extends ServiceTestBase {
                     .isThrownBy(() -> orderService.findByIdAndOrdererInfo(fakeId, request));
         }
 
-        @DisplayName("할 떄, 주문자 정보가 다르면 예외가 발생한다.")
+        @DisplayName("할 때, 주문자 정보가 다르면 예외가 발생한다.")
         @Test
         void throwsException_whenWrongPhone() {
             // given
@@ -259,7 +259,7 @@ class OrderServiceTest extends ServiceTestBase {
                     .withMessageContaining("접수된 주문");
         }
 
-        @DisplayName("할 떄, 주문이 존재하지 않으면 예외가 발생한다.")
+        @DisplayName("할 때, 주문이 존재하지 않으면 예외가 발생한다.")
         @Test
         void throwsException_whenWrongId() {
             // given
@@ -272,7 +272,7 @@ class OrderServiceTest extends ServiceTestBase {
                     .isThrownBy(() -> orderService.cancel(fakeId, request));
         }
 
-        @DisplayName("할 떄, 주문자 정보가 다르면 예외가 발생한다.")
+        @DisplayName("할 때, 주문자 정보가 다르면 예외가 발생한다.")
         @Test
         void throwsException_whenWrongPhone() {
             // given
@@ -315,7 +315,7 @@ class OrderServiceTest extends ServiceTestBase {
             );
         }
 
-        @DisplayName("할 떄, 소유하지 않은 푸드트럭의 주문이면 예외가 발생한다.")
+        @DisplayName("할 때, 소유하지 않은 푸드트럭의 주문이면 예외가 발생한다.")
         @Test
         void throwsException_whenNotOwnerOfOrder() {
             // given
@@ -328,7 +328,7 @@ class OrderServiceTest extends ServiceTestBase {
                     .withMessageContaining("소유하지 않은 푸드트럭의 주문");
         }
 
-        @DisplayName("할 떄, 해당 주문이 존재하지 않으면 예외가 발생한다.")
+        @DisplayName("할 때, 해당 주문이 존재하지 않으면 예외가 발생한다.")
         @Test
         void throwsException_whenOrderInfoNotFound() {
             // given
@@ -391,7 +391,7 @@ class OrderServiceTest extends ServiceTestBase {
             );
         }
 
-        @DisplayName("할 떄, 소유한 푸드트럭이 없으면 예외가 발생한다.")
+        @DisplayName("할 때, 소유한 푸드트럭이 없으면 예외가 발생한다.")
         @Test
         void throwsException_whenNoOwningTruck() {
             // given

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/order/service/OrderServiceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/order/service/OrderServiceTest.java
@@ -63,7 +63,7 @@ class OrderServiceTest extends ServiceTestBase {
             dataSetup.setEventOpen(savedEvent);
         }
 
-        @DisplayName("주문을 생성한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given & when
@@ -78,7 +78,7 @@ class OrderServiceTest extends ServiceTestBase {
             assertThat(id).isNotNull();
         }
 
-        @DisplayName("행사가 열려있지 않으면 예외가 발생한다.")
+        @DisplayName("할 때, 행사가 열려있지 않으면 예외가 발생한다.")
         @Test
         void throwsException_whenEventIsClosed() {
             // given
@@ -97,7 +97,7 @@ class OrderServiceTest extends ServiceTestBase {
                     .withMessageContaining("운영 시간");
         }
 
-        @DisplayName("존재하지 않는 푸드트럭에 주문하면 예외가 발생한다.")
+        @DisplayName("할 떄, 푸드트럭이 존재하지 않으면 예외가 발생한다.")
         @Test
         void throwsException_whenTruckNotFound() {
             // given
@@ -114,7 +114,7 @@ class OrderServiceTest extends ServiceTestBase {
                     .withMessageContaining("푸드트럭");
         }
 
-        @DisplayName("존재하지 않는 메뉴를 주문하면 예외가 발생한다.")
+        @DisplayName("할 떄, 존재하지 않는 메뉴면 예외가 발생한다.")
         @Test
         void throwsException_whenMenuNotFound() {
             // given
@@ -131,7 +131,7 @@ class OrderServiceTest extends ServiceTestBase {
                     .withMessageContaining("메뉴");
         }
 
-        @DisplayName("해당 푸드트럭의 메뉴가 아닌 메뉴를 주문하면 예외가 발생한다.")
+        @DisplayName("할 떄, 해당 푸드트럭의 메뉴가 아니면 예외가 발생한다.")
         @Test
         void throwsException_whenMenuOfOtherTruck() {
             // given
@@ -150,7 +150,7 @@ class OrderServiceTest extends ServiceTestBase {
                     .withMessageContaining("다른 푸드트럭");
         }
 
-        @DisplayName("품절된 메뉴를 주문하면 예외가 발생한다.")
+        @DisplayName("할 때, 품절된 메뉴면 예외가 발생한다.")
         @Test
         void throwsException_whenMenuSoldOut() {
             // given
@@ -169,11 +169,11 @@ class OrderServiceTest extends ServiceTestBase {
         }
     }
 
-    @DisplayName("주문자 주문 상세 정보 조회")
+    @DisplayName("id와 주문자 정보로 상세 정보 조회")
     @Nested
     class findByIdAndOrdererInfo {
 
-        @DisplayName("주문 상세 정보를 id와 주문자 정보로 조회한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -203,7 +203,7 @@ class OrderServiceTest extends ServiceTestBase {
             );
         }
 
-        @DisplayName("id가 옳지 않으면 예외가 발생한다.")
+        @DisplayName("할 때, 해당하는 주문이 존재하지 않으면 예외가 발생한다.")
         @Test
         void throwsException_whenWrongId() {
             // given
@@ -216,7 +216,7 @@ class OrderServiceTest extends ServiceTestBase {
                     .isThrownBy(() -> orderService.findByIdAndOrdererInfo(fakeId, request));
         }
 
-        @DisplayName("휴대폰 번호가 옳지 않으면 예외가 발생한다.")
+        @DisplayName("할 떄, 주문자 정보가 다르면 예외가 발생한다.")
         @Test
         void throwsException_whenWrongPhone() {
             // given
@@ -234,7 +234,7 @@ class OrderServiceTest extends ServiceTestBase {
     @Nested
     class cancel {
 
-        @DisplayName("주문을 취소한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -246,7 +246,7 @@ class OrderServiceTest extends ServiceTestBase {
                     .isThrownBy(() -> orderService.cancel(order.getId(), request));
         }
 
-        @DisplayName("이미 접수된 주문을 취소하면 예외가 발생한다.")
+        @DisplayName("할 때, 이미 접수된 주문이면 예외가 발생한다.")
         @Test
         void throwsException_whenOrderAccepted() {
             // given
@@ -259,7 +259,7 @@ class OrderServiceTest extends ServiceTestBase {
                     .withMessageContaining("접수된 주문");
         }
 
-        @DisplayName("id가 옳지 않으면 예외가 발생한다.")
+        @DisplayName("할 떄, 주문이 존재하지 않으면 예외가 발생한다.")
         @Test
         void throwsException_whenWrongId() {
             // given
@@ -272,7 +272,7 @@ class OrderServiceTest extends ServiceTestBase {
                     .isThrownBy(() -> orderService.cancel(fakeId, request));
         }
 
-        @DisplayName("휴대폰 번호가 옳지 않으면 예외가 발생한다.")
+        @DisplayName("할 떄, 주문자 정보가 다르면 예외가 발생한다.")
         @Test
         void throwsException_whenWrongPhone() {
             // given
@@ -286,11 +286,11 @@ class OrderServiceTest extends ServiceTestBase {
         }
     }
 
-    @DisplayName("사장님 소유 푸드트럭의 특정 주문 정보 조회")
+    @DisplayName("id로 사장님 소유 푸드트럭의 특정 주문 정보 조회")
     @Nested
     class findByIdAndOwnerId {
 
-        @DisplayName("소유한 푸드트럭의 주문 정보를 id로 조회한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -315,7 +315,7 @@ class OrderServiceTest extends ServiceTestBase {
             );
         }
 
-        @DisplayName("소유하지 않은 푸드트럭의 주문 정보를 조회하면 예외가 발생한다.")
+        @DisplayName("할 떄, 소유하지 않은 푸드트럭의 주문이면 예외가 발생한다.")
         @Test
         void throwsException_whenNotOwnerOfOrder() {
             // given
@@ -328,7 +328,7 @@ class OrderServiceTest extends ServiceTestBase {
                     .withMessageContaining("소유하지 않은 푸드트럭의 주문");
         }
 
-        @DisplayName("해당하는 주문 정보가 존재하지 않으면 예외가 발생한다.")
+        @DisplayName("할 떄, 해당 주문이 존재하지 않으면 예외가 발생한다.")
         @Test
         void throwsException_whenOrderInfoNotFound() {
             // given
@@ -345,7 +345,7 @@ class OrderServiceTest extends ServiceTestBase {
     @Nested
     class findOrdersByOwnerIdAndStatus {
 
-        @DisplayName("특정 주문 상태의 주문 목록을 최신순으로 정렬하여 page 단위로 조회한다.")
+        @DisplayName("하면 최신순으로 정렬하여 페이지 단위로 조회한다.")
         @Test
         void latest_perPage() {
             // given
@@ -365,7 +365,7 @@ class OrderServiceTest extends ServiceTestBase {
             assertThat(response.orders()).hasSize(1);
         }
 
-        @DisplayName("상태가 ALL이면 모든 주문을 최신순으로 정렬하여 page 단위로 조회한다.")
+        @DisplayName("할 때, 상태가 ALL이면 모든 주문을 최신순으로 정렬하여 page 단위로 조회한다.")
         @Test
         void all_latest_perPage() {
             // given
@@ -391,7 +391,7 @@ class OrderServiceTest extends ServiceTestBase {
             );
         }
 
-        @DisplayName("소유한 푸드트럭이 없으면 예외가 발생한다.")
+        @DisplayName("할 떄, 소유한 푸드트럭이 없으면 예외가 발생한다.")
         @Test
         void throwsException_whenNoOwningTruck() {
             // given
@@ -410,7 +410,7 @@ class OrderServiceTest extends ServiceTestBase {
     @Nested
     class changeStatus {
 
-        @DisplayName("주문 상태를 변경한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -422,7 +422,7 @@ class OrderServiceTest extends ServiceTestBase {
                     .isThrownBy(() -> orderService.changeStatus(request, orderInfo.getId(), owner.getId()));
         }
 
-        @DisplayName("소유한 푸드트럭이 없으면 예외가 발생한다.")
+        @DisplayName("할 때, 소유한 푸드트럭이 없으면 예외가 발생한다.")
         @Test
         void throwsException_whenNoOwningTruck() {
             // given
@@ -437,7 +437,7 @@ class OrderServiceTest extends ServiceTestBase {
                     .withMessageContainingAll("소유한 푸드트럭", "존재하지 않습니다.");
         }
 
-        @DisplayName("소유하지 않은 푸드트럭의 주문 상태를 변경하면 예외가 발생한다.")
+        @DisplayName("할 떄, 소유하지 않은 푸드트럭의 주문이면 예외가 발생한다.")
         @Test
         void throwsException_whenNotOwnerOfOrder() {
             // given

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/truck/OwnerTruckAcceptanceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/truck/OwnerTruckAcceptanceTest.java
@@ -1,4 +1,4 @@
-package com.connectruck.foodtruck.truck.controller;
+package com.connectruck.foodtruck.truck;
 
 import static com.connectruck.foodtruck.common.fixture.data.EventFixture.밤도깨비_야시장;
 import static org.hamcrest.Matchers.equalTo;

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/truck/TruckAcceptanceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/truck/TruckAcceptanceTest.java
@@ -74,7 +74,7 @@ public class TruckAcceptanceTest extends AcceptanceTestBase {
                     .body("trucks.name", contains(expected.getName()));
         }
 
-        @DisplayName("할 떄 사이즈와 페이지를 지정하지 않으면 첫 20개를 조회한다.")
+        @DisplayName("할 때, 사이즈와 페이지를 지정하지 않으면 첫 20개를 조회한다.")
         @Test
         void findFirst20_withNoPageAndSize() {
             // given

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/truck/TruckAcceptanceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/truck/TruckAcceptanceTest.java
@@ -19,11 +19,28 @@ public class TruckAcceptanceTest extends AcceptanceTestBase {
 
     private static final String BASE_URI = "/api/trucks";
 
-    @DisplayName("행사 참가 푸드트럭 목록 조회")
+    @DisplayName("특정 푸드트럭의 정보를 id로 조회한다.")
+    @Test
+    void findOneById() {
+        // given
+        final Event event = 밤도깨비_야시장.create();
+        dataSetup.saveEvent(event);
+        final Truck expected = dataSetup.saveTruck(event);
+
+        // when
+        final ValidatableResponse response = get(String.format(BASE_URI + "/%d", expected.getId()));
+
+        // then
+        response.statusCode(OK.value())
+                .body("id", equalTo(expected.getId().intValue()))
+                .body("name", equalTo(expected.getName()));
+    }
+
+    @DisplayName("행사 참가 푸드트럭 목록 페이지 조회")
     @Nested
     class findParticipatingTrucksByEvent {
 
-        @DisplayName("특정 페이지를 조회한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void perPage() {
             // given
@@ -57,7 +74,7 @@ public class TruckAcceptanceTest extends AcceptanceTestBase {
                     .body("trucks.name", contains(expected.getName()));
         }
 
-        @DisplayName("사이즈와 페이지를 지정하지 않으면 첫 20개를 조회한다.")
+        @DisplayName("할 떄 사이즈와 페이지를 지정하지 않으면 첫 20개를 조회한다.")
         @Test
         void findFirst20_withNoPageAndSize() {
             // given
@@ -70,28 +87,6 @@ public class TruckAcceptanceTest extends AcceptanceTestBase {
             response.statusCode(OK.value())
                     .body("page.size", equalTo(20))
                     .body("page.currentPage", equalTo(0));
-        }
-    }
-
-    @DisplayName("푸드트럭 정보 조회")
-    @Nested
-    class findOneTruck {
-
-        @DisplayName("특정 푸드트럭의 정보를 id로 조회한다.")
-        @Test
-        void byId() {
-            // given
-            final Event event = 밤도깨비_야시장.create();
-            dataSetup.saveEvent(event);
-            final Truck expected = dataSetup.saveTruck(event);
-
-            // when
-            final ValidatableResponse response = get(String.format(BASE_URI + "/%d", expected.getId()));
-
-            // then
-            response.statusCode(OK.value())
-                    .body("id", equalTo(expected.getId().intValue()))
-                    .body("name", equalTo(expected.getName()));
         }
     }
 }

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/truck/TruckAcceptanceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/truck/TruckAcceptanceTest.java
@@ -1,4 +1,4 @@
-package com.connectruck.foodtruck.truck.controller;
+package com.connectruck.foodtruck.truck;
 
 import static com.connectruck.foodtruck.common.fixture.data.EventFixture.밤도깨비_야시장;
 import static com.connectruck.foodtruck.common.fixture.data.EventFixture.서울FC_경기;

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/truck/controller/TruckControllerTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/truck/controller/TruckControllerTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.connectruck.foodtruck.common.testbase.ControllerTestBase;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.test.web.servlet.ResultActions;
@@ -15,22 +14,17 @@ class TruckControllerTest extends ControllerTestBase {
 
     private static final String BASE_URI = "/api/trucks";
 
-    @DisplayName("행사 참가 푸드트럭 목록 조회")
-    @Nested
-    class findByEvent {
+    @DisplayName("행사 참가 푸드트럭 목록 조회할 때, 페이지 번호 또는 사이즈가 음수일 경우 BadRequest를 응답한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"page", "size"})
+    void findByEvent_returnBadRequest_whenPageIsNegative(final String paramKey) throws Exception {
+        // given & when
+        final ResultActions resultActions = performGet(String.format(BASE_URI + "?eventId=1&%s=-1", paramKey));
 
-        @DisplayName("페이지 번호 또는 사이즈가 음수일 경우 BadRequest를 응답한다.")
-        @ParameterizedTest
-        @ValueSource(strings = {"page", "size"})
-        void returnBadRequest_whenPageIsNegative(final String paramKey) throws Exception {
-            // given & when
-            final ResultActions resultActions = performGet(String.format(BASE_URI + "?eventId=1&%s=-1", paramKey));
-
-            // then
-            resultActions
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("title").value("요청 파라미터값이 올바르지 않습니다."))
-                    .andExpect(jsonPath("detail", stringContainsInOrder("최소값")));
-        }
+        // then
+        resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("title").value("요청 파라미터값이 올바르지 않습니다."))
+                .andExpect(jsonPath("detail", stringContainsInOrder("최소값")));
     }
 }

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/truck/service/TruckServiceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/truck/service/TruckServiceTest.java
@@ -115,7 +115,7 @@ class TruckServiceTest extends ServiceTestBase {
             );
         }
 
-        @DisplayName("할 떄, 해당하는 푸드트럭이 존재하지 않으면 예외가 발생한다.")
+        @DisplayName("할 때, 해당하는 푸드트럭이 존재하지 않으면 예외가 발생한다.")
         @Test
         void throwsException_whenTruckNotFound() {
             // given

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/truck/service/TruckServiceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/truck/service/TruckServiceTest.java
@@ -57,11 +57,11 @@ class TruckServiceTest extends ServiceTestBase {
         );
     }
 
-    @DisplayName("푸드트럭 정보 조회")
+    @DisplayName("id로 푸드트럭 정보 조회")
     @Nested
     class findById {
 
-        @DisplayName("특정 푸드트럭의 정보를 id로 조회한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -77,7 +77,7 @@ class TruckServiceTest extends ServiceTestBase {
             );
         }
 
-        @DisplayName("해당하는 푸드트럭이 존재하지 않으면 예외가 발생한다.")
+        @DisplayName("할 때, 해당하는 푸드트럭이 존재하지 않으면 예외가 발생한다.")
         @Test
         void throwsException_whenTruckNotFound() {
             // given
@@ -91,11 +91,11 @@ class TruckServiceTest extends ServiceTestBase {
 
     }
 
-    @DisplayName("사장님 소유 푸드트럭 정보 조회")
+    @DisplayName("사장님 id로 소유 푸드트럭 정보 조회")
     @Nested
     class findByOwnerId {
 
-        @DisplayName("특정 푸드트럭의 정보를 사장님 계정 id로 조회한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -115,7 +115,7 @@ class TruckServiceTest extends ServiceTestBase {
             );
         }
 
-        @DisplayName("해당하는 푸드트럭이 존재하지 않으면 예외가 발생한다.")
+        @DisplayName("할 떄, 해당하는 푸드트럭이 존재하지 않으면 예외가 발생한다.")
         @Test
         void throwsException_whenTruckNotFound() {
             // given

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/user/UserAcceptanceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/user/UserAcceptanceTest.java
@@ -36,13 +36,13 @@ public class UserAcceptanceTest extends AcceptanceTestBase {
                 .header(LOCATION, BASE_URI + "/me");
     }
 
-    @DisplayName("사용 가능한 아이디인지 검사한다.")
+    @DisplayName("사용 가능한 아이디인지 검사")
     @Nested
     class checkUsername {
 
         private static final String URI = BASE_URI + "/check-username";
 
-        @DisplayName("사용 가능하면 true를 반환한다.")
+        @DisplayName("하여 사용 가능할 경우 true를 반환한다.")
         @Test
         void returnTrue_whenUsernameAvailable() {
             // given & when
@@ -54,7 +54,7 @@ public class UserAcceptanceTest extends AcceptanceTestBase {
                     .body("isAvailable", equalTo(true));
         }
 
-        @DisplayName("사용 중인 아이디이면 false를 반환한다.")
+        @DisplayName("하여 사용 중인 아이디이면 false를 반환한다.")
         @Test
         void returnFalse_whenUsernameAlreadyExists() {
             // given
@@ -70,13 +70,13 @@ public class UserAcceptanceTest extends AcceptanceTestBase {
         }
     }
 
-    @DisplayName("사용 가능한 휴대폰 번호인지 검사한다.")
+    @DisplayName("사용 가능한 휴대폰 번호인지 검사")
     @Nested
     class checkPhone {
 
         private static final String URI = BASE_URI + "/check-phone";
 
-        @DisplayName("사용 가능하면 true를 반환한다.")
+        @DisplayName("하여 사용 가능하면 true를 반환한다.")
         @Test
         void returnTrue_whenPhoneAvailable() {
             // given & when
@@ -88,7 +88,7 @@ public class UserAcceptanceTest extends AcceptanceTestBase {
                     .body("isAvailable", equalTo(true));
         }
 
-        @DisplayName("사용 중인 휴대폰 번호이면 false를 반환한다.")
+        @DisplayName("하여 사용 중인 휴대폰 번호이면 false를 반환한다.")
         @Test
         void returnFalse_whenPhoneAlreadyExists() {
             // given

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/user/UserAcceptanceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/user/UserAcceptanceTest.java
@@ -1,4 +1,4 @@
-package com.connectruck.foodtruck.user.controller;
+package com.connectruck.foodtruck.user;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.http.HttpHeaders.LOCATION;
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 public class UserAcceptanceTest extends AcceptanceTestBase {
 
     private static final String BASE_URI = "/api/users";
+
     private final String username = "test";
     private final String password = "test1234!";
     private final String phone = "01000000000";

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/user/controller/UserControllerTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/user/controller/UserControllerTest.java
@@ -24,7 +24,7 @@ public class UserControllerTest extends ControllerTestBase {
     private final String password = "test1234!";
     private final String phone = "01000000000";
 
-    @DisplayName("아이디 검사 요청 시, 아이디가 비어있을 경우 Bad Request를 응답한다.")
+    @DisplayName("아이디 검사 요청 할 때, 아이디가 비어있을 경우 Bad Request를 응답한다.")
     @ParameterizedTest
     @NullAndEmptySource
     void checkUsername_returnBadRequest_whenUsernameIsBlank(final String blank) throws Exception {
@@ -39,7 +39,7 @@ public class UserControllerTest extends ControllerTestBase {
                 .andExpect(jsonPath("detail", stringContainsInOrder("필수", "아이디")));
     }
 
-    @DisplayName("휴대폰 번호 검사 요청 시, 휴대폰 번호 형식이 잘못되었을 경우 Bad Request를 응답한다.")
+    @DisplayName("휴대폰 번호 검사 요청 할 때, 휴대폰 번호 형식이 잘못되었을 경우 Bad Request를 응답한다.")
     @ParameterizedTest
     @ValueSource(strings = {"11012341234", "01212341234", "010121234", "010a1231234", "010-1234-1234"})
     void checkPhone_returnBadRequest_whenPhoneInvalid(final String invalidPhone) throws Exception {
@@ -58,7 +58,7 @@ public class UserControllerTest extends ControllerTestBase {
     @Nested
     class create {
 
-        @DisplayName("아이디가 비어있을 경우 Bad Request를 응답한다.")
+        @DisplayName("할 때, 아이디가 비어있으면 Bad Request를 응답한다.")
         @ParameterizedTest
         @NullAndEmptySource
         void returnBadRequest_whenUsernameIsBlank(final String blank) throws Exception {
@@ -73,7 +73,7 @@ public class UserControllerTest extends ControllerTestBase {
                     .andExpect(jsonPath("detail", stringContainsInOrder("필수", "아이디")));
         }
 
-        @DisplayName("비밀번호 형식이 잘못되었을 경우 Bad Request를 응답한다.")
+        @DisplayName("할 때, 비밀번호 형식이 잘못되었으면 Bad Request를 응답한다.")
         @ParameterizedTest
         @ValueSource(strings = {"new1234", "12345678!", "newpass!", "newpw1!", "123456789a123456789a123456789a!"})
         void returnBadRequest_whenPasswordInvalid(final String invalidPassword) throws Exception {
@@ -88,7 +88,7 @@ public class UserControllerTest extends ControllerTestBase {
                     .andExpect(jsonPath("detail", stringContainsInOrder("형식", "비밀번호")));
         }
 
-        @DisplayName("휴대폰 번호 형식이 잘못되었을 경우 Bad Request를 응답한다.")
+        @DisplayName("할 때, 휴대폰 번호 형식이 잘못되었으면 Bad Request를 응답한다.")
         @ParameterizedTest
         @ValueSource(strings = {"11012341234", "01212341234", "010121234", "010a1231234", "010-1234-1234"})
         void returnBadRequest_whenPhoneInvalid(final String invalidPhone) throws Exception {
@@ -103,7 +103,7 @@ public class UserControllerTest extends ControllerTestBase {
                     .andExpect(jsonPath("detail", stringContainsInOrder("형식", "휴대폰 번호")));
         }
 
-        @DisplayName("계정 권한이 비어있는 경우 Bad Request를 응답한다.")
+        @DisplayName("할 때, 계정 권한이 비어있으면 Bad Request를 응답한다.")
         @Test
         void returnBadRequest_whenRoleIsNull() throws Exception {
             // given & when

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/user/domain/EncodedPasswordTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/user/domain/EncodedPasswordTest.java
@@ -12,11 +12,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class EncodedPasswordTest {
 
-    @DisplayName("평문 비밀번호를 암호화한다.")
+    @DisplayName("평문 비밀번호 암호화")
     @Nested
     class fromPlainText {
 
-        @DisplayName("평문 비밀번호를 암호화한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void success() {
             // given
@@ -29,7 +29,7 @@ class EncodedPasswordTest {
             assertThat(encodedPassword.isSamePassword(plainText)).isTrue();
         }
 
-        @DisplayName("비밀번호 형식이 잘못되었을 경우 예외가 발생한다.")
+        @DisplayName("할 때, 비밀번호 형식이 잘못되었으면 예외가 발생한다.")
         @ParameterizedTest
         @ValueSource(strings = {"new1234", "12345678!", "newpass!", "newpw1!", "123456789a123456789a123456789a!"})
         void throwsException_whenFormatInvalid(final String invalidText) {

--- a/backend/foodtruck/src/test/java/com/connectruck/foodtruck/user/service/UserServiceTest.java
+++ b/backend/foodtruck/src/test/java/com/connectruck/foodtruck/user/service/UserServiceTest.java
@@ -32,7 +32,7 @@ public class UserServiceTest extends ServiceTestBase {
     @Nested
     class checkUsername {
 
-        @DisplayName("사용 가능한 아이디일 경우 true를 반환한다.")
+        @DisplayName("하면 사용 가능한 아이디일 경우 true를 반환한다.")
         @Test
         void returnTrue_whenUsernameAvailable() {
             // given & when
@@ -43,7 +43,7 @@ public class UserServiceTest extends ServiceTestBase {
             assertThat(response.isAvailable()).isTrue();
         }
 
-        @DisplayName("사용 중인 아이디일 경우 false를 반환한다.")
+        @DisplayName("하면 사용 중인 아이디일 경우 false를 반환한다.")
         @Test
         void returnFalse_whenUsernameAlreadyExists() {
             // given
@@ -62,7 +62,7 @@ public class UserServiceTest extends ServiceTestBase {
     @Nested
     class checkPhone {
 
-        @DisplayName("사용 가능한 아이디일 경우 true를 반환한다.")
+        @DisplayName("하면 사용 가능한 아이디일 경우 true를 반환한다.")
         @Test
         void returnTrue_whenPhoneAvailable() {
             // given & when
@@ -73,7 +73,7 @@ public class UserServiceTest extends ServiceTestBase {
             assertThat(response.isAvailable()).isTrue();
         }
 
-        @DisplayName("사용 중인 휴대폰 번호일 경우 false를 반환한다.")
+        @DisplayName("하면 사용 중인 휴대폰 번호일 경우 false를 반환한다.")
         @Test
         void returnFalse_whenPhoneAlreadyExists() {
             // given
@@ -92,7 +92,7 @@ public class UserServiceTest extends ServiceTestBase {
     @Nested
     class create {
 
-        @DisplayName("사장님 회원 정보를 생성한다.")
+        @DisplayName("할 수 있다.")
         @Test
         void asOwner() {
             final UserRequest request = new UserRequest(username, password, phone, Role.OWNER);
@@ -100,7 +100,7 @@ public class UserServiceTest extends ServiceTestBase {
                     .isThrownBy(() -> userService.create(request));
         }
 
-        @DisplayName("사용중인 아이디일 경우 예외가 발생한다.")
+        @DisplayName("할 때, 사용중인 아이디면 예외가 발생한다.")
         @Test
         void throwsException_whenUsernameExist() {
             // given
@@ -114,7 +114,7 @@ public class UserServiceTest extends ServiceTestBase {
                     .withMessageContaining("존재하는 아이디");
         }
 
-        @DisplayName("사용중인 휴대폰 번호일 경우 예외가 발생한다.")
+        @DisplayName("할 떄, 사용중인 휴대폰 번호면 예외가 발생한다.")
         @Test
         void throwsException_whenPhoneExist() {
             // given

--- a/backend/foodtruck/src/test/resources/application.yml
+++ b/backend/foodtruck/src/test/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   # jpa
   jpa:
+    database-platform: org.hibernate.dialect.MySQL8Dialect
     properties:
       hibernate:
         format_sql: true

--- a/backend/foodtruck/src/test/resources/truncate.sql
+++ b/backend/foodtruck/src/test/resources/truncate.sql
@@ -6,6 +6,8 @@ TRUNCATE TABLE order_info;
 
 TRUNCATE TABLE menu;
 
+TRUNCATE TABLE push_subscription;
+
 TRUNCATE TABLE truck;
 
 TRUNCATE TABLE schedule;


### PR DESCRIPTION
### Motivation
<!--요구 사항 또는 작업 동기-->
- `DisplayName`을 nested class와 test method가 문장형으로 이어지도록 수정
- test result의 가독성 개선

### Key Changes
<!--주요한 변화들-->
- `DisplayName ` 문장형으로 수정
    - Nested class에서는 명사형으로 기능 명시
    - test method에서는 각 case의 상황을 문장형으로 명시
    - 성공 case -> `할 수 있다`, `하여`, `하면`
    - 예외 case -> `할 때, `
- AcceptanceTest 각 도메인 영역 패키지 최상단으로 이동
    - test를 통한 기능 파악 시 AcceptanceTest에서 전체적인 use case 먼저 파악할 수 있도록
    - controller test package에는 controller 단위 test만 포함
- hibernate dialect 설정 추가
    - test에서 h2 DB로 실행되어도 MySQL 문법의 쿼리 확인할 수 있도록

### Note
<!--참고 사항 및 추가로 작성하고 싶은 내용-->

<!--관련 이슈 있을 경우-->
<!--Close #{이슈번호}-->
